### PR TITLE
Adjacency generalisation & separation of pattern-based adjacency from solving

### DIFF
--- a/example/elm.json
+++ b/example/elm.json
@@ -21,6 +21,7 @@
             "elm-community/list-extra": "8.2.4",
             "joakin/elm-canvas": "4.2.1",
             "justgook/elm-image": "4.0.0",
+            "toastal/either": "3.5.2",
             "wernerdegroot/listzipper": "4.0.0",
             "ymtszw/elm-xml-decode": "3.2.1"
         },

--- a/example/index.html
+++ b/example/index.html
@@ -21,14 +21,14 @@
 
     var jsWorker = new Worker('./worker-runner.js');
 
-    mehanik.ports.runInWorker.subscribe(({ options, source, adjacency }) => {
+    mehanik.ports.runInWorker.subscribe(({ options, adjacency }) => {
         jsWorker.postMessage(
-            { 'cmd': 'run', 'source': source, 'options': options, 'adjacency': adjacency }
+            { 'cmd': 'run', 'options': options, 'adjacency': adjacency }
         );
     });
-    mehanik.ports.traceInWorker.subscribe(({ options, source, adjacency }) => {
+    mehanik.ports.traceInWorker.subscribe(({ options, adjacency }) => {
         jsWorker.postMessage(
-            { 'cmd': 'trace', 'source': source, 'options': options, 'adjacency': adjacency }
+            { 'cmd': 'trace', 'options': options, 'adjacency': adjacency }
         );
     });
     mehanik.ports.stepInWorker.subscribe((_) => {
@@ -40,9 +40,9 @@
     mehanik.ports.stopWorker.subscribe((_) => {
         jsWorker.postMessage({ 'cmd': 'stop' });
     });
-    mehanik.ports.preprocessInWorker.subscribe(({ options, source, adjacency }) => {
+    mehanik.ports.preprocessInWorker.subscribe(({ options, source }) => {
         jsWorker.postMessage(
-            { 'cmd': 'preprocess', 'source': source, 'options': options, 'adjacency': adjacency }
+            { 'cmd': 'preprocess', 'options': options, 'source': source }
         );
     });
     mehanik.ports.getMatchesAt.subscribe(position => {
@@ -58,7 +58,7 @@
             case 'step':
                 mehanik.ports.gotWorkerResult.send(data.wave);
             case 'patterns':
-                mehanik.ports.gotPatternsFromWorker.send(data.patterns);
+                mehanik.ports.gotAdjacencyFromWorker.send(data.patterns);
             case 'matches':
                 mehanik.ports.gotMatchesFromWorker.send(data.matches);
             default: return;

--- a/example/index.html
+++ b/example/index.html
@@ -21,11 +21,15 @@
 
     var jsWorker = new Worker('./worker-runner.js');
 
-    mehanik.ports.runInWorker.subscribe(({ options, source }) => {
-        jsWorker.postMessage({ 'cmd': 'run', 'source': source, 'options': options });
+    mehanik.ports.runInWorker.subscribe(({ options, source, adjacency }) => {
+        jsWorker.postMessage(
+            { 'cmd': 'run', 'source': source, 'options': options, 'adjacency': adjacency }
+        );
     });
-    mehanik.ports.traceInWorker.subscribe(({ options, source }) => {
-        jsWorker.postMessage({ 'cmd': 'trace', 'source': source, 'options': options });
+    mehanik.ports.traceInWorker.subscribe(({ options, source, adjacency }) => {
+        jsWorker.postMessage(
+            { 'cmd': 'trace', 'source': source, 'options': options, 'adjacency': adjacency }
+        );
     });
     mehanik.ports.stepInWorker.subscribe((_) => {
         jsWorker.postMessage({ 'cmd': 'step' });
@@ -36,8 +40,10 @@
     mehanik.ports.stopWorker.subscribe((_) => {
         jsWorker.postMessage({ 'cmd': 'stop' });
     });
-    mehanik.ports.preprocessInWorker.subscribe(({ options, source }) => {
-        jsWorker.postMessage({ 'cmd': 'preprocess', 'source': source, 'options': options });
+    mehanik.ports.preprocessInWorker.subscribe(({ options, source, adjacency }) => {
+        jsWorker.postMessage(
+            { 'cmd': 'preprocess', 'source': source, 'options': options, 'adjacency': adjacency }
+        );
     });
     mehanik.ports.getMatchesAt.subscribe(position => {
         jsWorker.postMessage({ 'cmd': 'matches', 'position': position });

--- a/example/mehanik/Mehanik.elm
+++ b/example/mehanik/Mehanik.elm
@@ -1410,6 +1410,7 @@ changeN n options =
             _ -> options.approach
     }
 
+
 changeSymmetry : Symmetry -> Solver.Options -> Solver.Options
 changeSymmetry symmetry options =
     { options

--- a/example/mehanik/Mehanik.elm
+++ b/example/mehanik/Mehanik.elm
@@ -237,7 +237,7 @@ init =
 
 defaultOptions =
     { approach =
-        Overlapping
+        PatternSearch
             { inputBoundary = Bounded -- Periodic
             , patternSize = ( 2, 2 )
             , symmetry = FlipAndRotate
@@ -1029,7 +1029,7 @@ view model =
 
         controls options  =
             case options.approach of
-                Overlapping { patternSize, inputBoundary, symmetry } ->
+                PatternSearch { patternSize, inputBoundary, symmetry } ->
 
                     div
                         []
@@ -1402,8 +1402,8 @@ changeN n options =
     { options
     | approach =
         case options.approach of
-            Overlapping overlappingOpts ->
-                Overlapping
+            PatternSearch overlappingOpts ->
+                PatternSearch
                     { overlappingOpts
                     | patternSize = n
                     }
@@ -1415,8 +1415,8 @@ changeSymmetry symmetry options =
     { options
     | approach =
         case options.approach of
-            Overlapping overlappingOpts ->
-                Overlapping
+            PatternSearch overlappingOpts ->
+                PatternSearch
                     { overlappingOpts
                     | symmetry = symmetry
                     }
@@ -1429,8 +1429,8 @@ changeInputBoundary boundary options =
     { options
     | approach =
         case options.approach of
-            Overlapping overlappingOpts ->
-                Overlapping
+            PatternSearch overlappingOpts ->
+                PatternSearch
                     { overlappingOpts
                     | inputBoundary = boundary
                     }

--- a/example/mehanik/Worker.elm
+++ b/example/mehanik/Worker.elm
@@ -12,8 +12,7 @@ import Kvant.Vec2 exposing (Vec2)
 import Kvant.Core exposing (Wfc)
 import Kvant.Core as Wfc
 import Kvant.Solver as Solver
-import Kvant.Solver.Options as Solver
-import Kvant.Solver.Options exposing (Approach(..))
+import Kvant.Solver.Options as Options
 import Kvant.Plane exposing (..)
 import Kvant.Json.Options as Options
 import Kvant.Json.Patterns as Patterns
@@ -23,6 +22,7 @@ import Kvant.Neighbours exposing (Neighbours)
 import Kvant.Neighbours as Neighbours
 import Kvant.Matches as Matches
 import Kvant.Adjacency as A
+
 
 type alias Adjacency = A.Adjacency Int Int
 
@@ -45,15 +45,15 @@ type Model
 
 
 type Msg
-    = Run Solver.Options Adjacency
-    | RunWith Solver.Options Adjacency Random.Seed
-    | Trace Solver.Options Adjacency
-    | TraceWith Solver.Options Adjacency Random.Seed
+    = Run Options.Output Adjacency
+    | RunWith Options.Output Adjacency Random.Seed
+    | Trace Options.Output Adjacency
+    | TraceWith Options.Output Adjacency Random.Seed
     | Step
     | StepBack
     | StepBackWith Random.Seed
     | Stop
-    | Preprocess Solver.Options Adjacency
+    | Preprocess Options.Overlapping Adjacency
     | GetMatchesAt Vec2
     | InformError String
 

--- a/example/mehanik/Worker.elm
+++ b/example/mehanik/Worker.elm
@@ -59,18 +59,6 @@ type Msg
     | InformError String
 
 
-defaultPatternSearchOptions : Options.PatternSearch
-defaultPatternSearchOptions =
-    { patternSize = (2, 2)
-    , boundary = Bounded
-    , symmetry = NoSymmetry
-    }
-
-
-defaultOutputOptions : Options.Output
-defaultOutputOptions = ( Bounded, (10, 10) )
-
-
 -- TODO: remove
 fromPlane : Plane (List Int) -> Array (Array (Array Int))
 fromPlane =
@@ -242,7 +230,7 @@ subscriptions : Model -> Sub Msg
 subscriptions _ =
     Sub.batch
         [ run <| \{options, adjacency} ->
-            case ( options |> D.decodeValue Options.decodeOutputOptions
+            case ( options |> D.decodeValue Options.decodeOutput
                  , adjacency |> D.decodeValue Adjacency.decode ) of
                 ( Ok decodedOptions, Ok decodedAdjacency ) -> Run decodedOptions decodedAdjacency
                 ( Err error, Ok _ ) -> InformError <| D.errorToString error
@@ -251,7 +239,7 @@ subscriptions _ =
                     InformError <| D.errorToString errorA ++ ". "  ++ D.errorToString errorB
 
         , trace <| \{options, adjacency} ->
-            case ( options |> D.decodeValue Options.decodeOutputOptions
+            case ( options |> D.decodeValue Options.decodeOutput
                  , adjacency |> D.decodeValue Adjacency.decode ) of
                 ( Ok decodedOptions, Ok decodedAdjacency ) -> Trace decodedOptions decodedAdjacency
                 ( Err error, Ok _ ) -> InformError <| D.errorToString error
@@ -262,7 +250,7 @@ subscriptions _ =
         , back <| always StepBack
         , stop <| always Stop
         , preprocess <| \{options, source } ->
-            case options |> D.decodeValue Options.decodePatternSearchOptions of
+            case options |> D.decodeValue Options.decodePatternSearch of
                 Ok decodedOptions -> Preprocess decodedOptions source
                 Err error -> InformError <| D.errorToString error
         , matchesAt GetMatchesAt

--- a/example/worker-runner.js
+++ b/example/worker-runner.js
@@ -31,10 +31,14 @@ self.addEventListener('message', function(e) {
     var data = e.data;
     switch (data.cmd) {
         case 'run':
-            app.ports.run.send({ options: data.options, source : data.source });
+            app.ports.run.send(
+                { options: data.options, source : data.source, adjacency : data.adjacency }
+            );
             break;
         case 'trace':
-            app.ports.trace.send({ options: data.options, source : data.source });
+            app.ports.trace.send(
+                { options: data.options, source : data.source, adjacency : data.adjacency }
+            );
             break;
         case 'step':
             app.ports.step.send(null);
@@ -46,7 +50,9 @@ self.addEventListener('message', function(e) {
             app.ports.stop.send(null);
             break;
         case 'preprocess':
-            app.ports.preprocess.send({ options: data.options, source : data.source });
+            app.ports.preprocess.send(
+                { options: data.options, source : data.source, adjacency : data.adjacency }
+            );
             break;
         case 'matches':
             console.log(data.position);

--- a/example/worker-runner.js
+++ b/example/worker-runner.js
@@ -32,12 +32,12 @@ self.addEventListener('message', function(e) {
     switch (data.cmd) {
         case 'run':
             app.ports.run.send(
-                { options: data.options, source : data.source, adjacency : data.adjacency }
+                { options: data.options, adjacency : data.adjacency }
             );
             break;
         case 'trace':
             app.ports.trace.send(
-                { options: data.options, source : data.source, adjacency : data.adjacency }
+                { options: data.options, adjacency : data.adjacency }
             );
             break;
         case 'step':
@@ -51,7 +51,7 @@ self.addEventListener('message', function(e) {
             break;
         case 'preprocess':
             app.ports.preprocess.send(
-                { options: data.options, source : data.source, adjacency : data.adjacency }
+                { options: data.options, source : data.source }
             );
             break;
         case 'matches':

--- a/src/Kvant/Adjacency.elm
+++ b/src/Kvant/Adjacency.elm
@@ -51,3 +51,7 @@ mapKey f =
 reflective : Adjacency i a -> Adjacency i i
 reflective =
     keyedMap (\k _ -> k)
+
+
+get : comparable -> Adjacency comparable a -> Maybe a
+get key = Dict.get key >> Maybe.map .subject

--- a/src/Kvant/Adjacency.elm
+++ b/src/Kvant/Adjacency.elm
@@ -23,3 +23,22 @@ type alias Adjacency subj_id subj =
 
 
 -- fromGrid : TileGrid -> Adjacency (TileKey, Rotation) (TileKey, Rotation)
+
+
+map : (a -> b) -> Adjacency i a -> Adjacency i b
+map f =
+    Dict.map
+        (\_ v ->
+            { subject = f v.subject
+            , weight = v.weight
+            , matches = v.matches
+            }
+        )
+
+
+mapKey : (comparable -> comparable) -> Adjacency comparable a -> Adjacency comparable a
+mapKey f =
+    Dict.toList
+        >> List.map (Tuple.mapFirst f)
+        >> Dict.fromList
+

--- a/src/Kvant/Adjacency.elm
+++ b/src/Kvant/Adjacency.elm
@@ -26,10 +26,15 @@ type alias Adjacency subj_id subj =
 
 
 map : (a -> b) -> Adjacency i a -> Adjacency i b
-map f =
+map =
+    keyedMap << always
+
+
+keyedMap : (i -> a -> b) -> Adjacency i a -> Adjacency i b
+keyedMap f =
     Dict.map
-        (\_ v ->
-            { subject = f v.subject
+        (\k v ->
+            { subject = f k v.subject
             , weight = v.weight
             , matches = v.matches
             }
@@ -42,3 +47,7 @@ mapKey f =
         >> List.map (Tuple.mapFirst f)
         >> Dict.fromList
 
+
+reflective : Adjacency i a -> Adjacency i i
+reflective =
+    keyedMap (\k _ -> k)

--- a/src/Kvant/Core.elm
+++ b/src/Kvant/Core.elm
@@ -1,8 +1,8 @@
 module Kvant.Core exposing
     ( Wfc
-    , firstStep
-    , run, step, stepAtOnce
     , make, makeAdvancing
+    , step, stepAtOnce
+    , firstStep
     )
 
 import Random
@@ -11,21 +11,21 @@ import Dict
 
 import Kvant.Vec2 exposing (..)
 import Kvant.Plane exposing (Plane, Size)
-import Kvant.Solver as Solver exposing (Step(..), Solution)
+import Kvant.Solver as Solver exposing (Step(..), Solution, Adjacency)
 import Kvant.Solver.Options as Solver exposing (Approach(..))
 import Kvant.Patterns as Patterns
 import Kvant.Matches exposing (..)
-import Kvant.Patterns exposing (UniquePatterns)
+-- import Kvant.Patterns exposing (UniquePatterns)
+-- import Kvant.Adjacency exposing (Adjacency)
 
 
 type Wfc =
-    -- may be `Plane (List Key)` is not needed, just extract it from the wave
-    Wfc Size ( Solver.Step -> ( Solver.Step, Solution ) )
+    Wfc ( Solver.Step -> Solver.Step )
 
 
-makeWith : (UniquePatterns -> Step -> Step) -> Solver.Options -> Plane Patterns.AtomId -> Wfc
-makeWith doStep options source =
-    let
+makeWith : (Adjacency a -> Step -> Step) -> Adjacency a -> Wfc
+makeWith doStep =
+    {- let
         uniquePatterns =
             case options.approach of
                 Overlapping o ->
@@ -33,38 +33,33 @@ makeWith doStep options source =
                         |> Patterns.preprocess o.symmetry o.inputBoundary o.patternSize
                 Tiled ->
                     Dict.empty
-    in
-    Wfc options.outputSize <|
-        \nextStep ->
-            let
-                lastStep = doStep uniquePatterns nextStep
-            in
-                ( lastStep
-                , lastStep |> Solver.produce uniquePatterns
-                )
+    in -}
+    Wfc << doStep
 
 
-make : Solver.Options -> Plane Patterns.AtomId -> Wfc
+make : Adjacency a -> Wfc
 make = makeWith Solver.solve
 
 
-makeAdvancing : Solver.Options -> Plane Patterns.AtomId -> Wfc
+makeAdvancing : Adjacency a -> Wfc
 makeAdvancing = makeWith Solver.advance
 
 
+{-
 run : Random.Seed -> Wfc -> Solution
 run seed wfc =
     -- FIXME: we do two steps actually, because with the first step the `Solver` inits the wave
     --        (see `Initial` status) and proceeds with solving only after that
     step (firstStep seed wfc |> Tuple.first) wfc
         |> Tuple.second
+-}
 
 
-step : Step -> Wfc -> ( Step, Solution )
-step stepToPerform (Wfc _ wfc) = wfc stepToPerform
+step : Step -> Wfc -> Step
+step stepToPerform (Wfc wfc) = wfc stepToPerform
 
 
-stepAtOnce : List Step -> Wfc -> Maybe ( Step, Solution )
+stepAtOnce : List Step -> Wfc -> Maybe Step
 stepAtOnce steps wfc =
     steps
         |> List.foldl
@@ -74,6 +69,6 @@ stepAtOnce steps wfc =
             Nothing
 
 
-firstStep : Random.Seed -> Wfc -> ( Step, Solution )
-firstStep seed (Wfc size _ as wfc) =
-    step (Solver.firstStep size seed) wfc
+firstStep : Random.Seed -> Size -> Wfc -> Step
+firstStep seed size =
+    step <| Solver.firstStep size seed

--- a/src/Kvant/Core.elm
+++ b/src/Kvant/Core.elm
@@ -10,10 +10,8 @@ import Random
 import Dict
 
 import Kvant.Vec2 exposing (..)
-import Kvant.Plane exposing (Plane, Size)
-import Kvant.Solver as Solver exposing (Step(..), Solution, Adjacency)
-import Kvant.Solver.Options as Solver exposing (Approach(..))
-import Kvant.Patterns as Patterns
+import Kvant.Plane exposing (Size)
+import Kvant.Solver as Solver exposing (Step(..), Adjacency)
 import Kvant.Matches exposing (..)
 -- import Kvant.Patterns exposing (UniquePatterns)
 -- import Kvant.Adjacency exposing (Adjacency)

--- a/src/Kvant/Core.elm
+++ b/src/Kvant/Core.elm
@@ -1,23 +1,22 @@
 module Kvant.Core exposing
     ( Wfc
     , make, makeAdvancing
+    , run
     , step, stepAtOnce
     , firstStep
     )
 
 import Random
 
-import Dict
-
 import Kvant.Vec2 exposing (..)
 import Kvant.Plane exposing (Size)
-import Kvant.Solver as Solver exposing (Step(..), Adjacency)
+import Kvant.Solver as Solver exposing (Step(..), Adjacency, Solution)
 import Kvant.Matches exposing (..)
 -- import Kvant.Patterns exposing (UniquePatterns)
 -- import Kvant.Adjacency exposing (Adjacency)
 
 
-type Wfc =
+type Wfc = -- FIXME: Store `Adjacency` inside
     Wfc ( Solver.Step -> Solver.Step )
 
 
@@ -26,7 +25,7 @@ makeWith doStep =
     {- let
         uniquePatterns =
             case options.approach of
-                Overlapping o ->
+                PatternSearch o ->
                     source
                         |> Patterns.preprocess o.symmetry o.inputBoundary o.patternSize
                 Tiled ->
@@ -43,14 +42,13 @@ makeAdvancing : Adjacency a -> Wfc
 makeAdvancing = makeWith Solver.advance
 
 
-{-
-run : Random.Seed -> Wfc -> Solution
-run seed wfc =
+-- FIXME: do not require adjacency for running
+run : Adjacency a -> Random.Seed -> Size -> Wfc -> Solution a
+run adjacency seed size (Wfc doStep as wfc) =
     -- FIXME: we do two steps actually, because with the first step the `Solver` inits the wave
     --        (see `Initial` status) and proceeds with solving only after that
-    step (firstStep seed wfc |> Tuple.first) wfc
-        |> Tuple.second
--}
+    doStep (wfc |> firstStep seed size)
+        |> Solver.produce adjacency
 
 
 step : Step -> Wfc -> Step
@@ -70,3 +68,4 @@ stepAtOnce steps wfc =
 firstStep : Random.Seed -> Size -> Wfc -> Step
 firstStep seed size =
     step <| Solver.firstStep size seed
+-- FIXME: do not perform, just return?

--- a/src/Kvant/Json/Adjacency.elm
+++ b/src/Kvant/Json/Adjacency.elm
@@ -18,7 +18,7 @@ encode : Adjacency Int Int -> E.Value
 encode = encodeWith E.int E.int
 
 
-encodeWith : (comparable -> E.Value) -> (a -> E.Value) -> Adjacency comparable a -> E.Value
+encodeWith : (i -> E.Value) -> (a -> E.Value) -> Adjacency i a -> E.Value
 encodeWith keyEncode itemEncode =
     Dict.toList
         >> E.list (encodeItem keyEncode itemEncode)

--- a/src/Kvant/Json/Adjacency.elm
+++ b/src/Kvant/Json/Adjacency.elm
@@ -1,0 +1,88 @@
+module Kvant.Json.Adjacency exposing (..)
+
+
+import Dict exposing (Dict)
+
+import Json.Encode as E
+import Json.Decode as D
+
+import Kvant.Plane as Plane
+import Kvant.Adjacency exposing (Adjacency)
+import Kvant.Matches as Matches exposing (Matches)
+
+
+encode : (a -> E.Value) -> Adjacency Int a -> E.Value
+encode itemEncode =
+    Dict.toList
+        >> E.list (encodeItem itemEncode)
+
+
+decode : D.Decoder a -> D.Decoder (Adjacency Int a)
+decode decodeItem =
+    D.list (decodeItems decodeItem)
+        |> D.map Dict.fromList
+
+
+decodeItems
+    :  D.Decoder a
+    -> D.Decoder
+        ( Int
+        ,
+            { subject : a
+            , weight : Float
+            , matches : Dict Plane.Offset (Matches Int)
+            }
+        )
+decodeItems decodeItem =
+    D.map2
+        Tuple.pair
+        (D.field "id" D.int)
+        <| D.map3
+            (\s w m -> { subject = s, weight = w, matches = m })
+            (D.field "subject" decodeItem)
+            (D.field "weight" D.float)
+            (D.field "matches" decodeMatches)
+
+
+decodeMatches : D.Decoder (Dict Plane.Offset (Matches Int))
+decodeMatches =
+    D.list
+        (D.map3
+            (\x y matches -> ( (x, y), Matches.fromList matches ))
+            (D.field "x" D.int)
+            (D.field "y" D.int)
+            (D.field "matches" <| D.list D.int)
+        )
+        |> D.map Dict.fromList
+
+
+encodeItem
+    :   ( a -> E.Value )
+    ->  ( Int
+        ,
+            { subject : a
+            , weight : Float
+            , matches : Dict Plane.Offset (Matches Int)
+            }
+        )
+    -> E.Value
+encodeItem itemEncode ( itemId, stats ) =
+    E.object
+        [ ( "id", E.int itemId )
+        , ( "subject", stats.subject |> itemEncode )
+        , ( "weight", stats.weight |> E.float )
+        ,
+            ( "matches"
+            , stats.matches
+                |> Dict.toList
+                |> E.list
+                    (\((x, y), matches) ->
+                        E.object
+                            [ ( "x", E.int x )
+                            , ( "y", E.int y )
+                            , ( "matches", matches |> Matches.toList |> E.list E.int )
+                            ]
+                    )
+            )
+        ]
+

--- a/src/Kvant/Json/Adjacency.elm
+++ b/src/Kvant/Json/Adjacency.elm
@@ -14,15 +14,23 @@ import Kvant.Matches as Matches exposing (Matches)
 -- TODO: merge in one `Adjacency Int Int`
 -- so that for Patterns and Tiles the principle would be the same
 
+encode : Adjacency Int Int -> E.Value
+encode = encodeWith E.int E.int
 
-encode : (comparable -> E.Value) -> (a -> E.Value) -> Adjacency comparable a -> E.Value
-encode keyEncode itemEncode =
+
+encodeWith : (comparable -> E.Value) -> (a -> E.Value) -> Adjacency comparable a -> E.Value
+encodeWith keyEncode itemEncode =
     Dict.toList
         >> E.list (encodeItem keyEncode itemEncode)
 
 
-decode : D.Decoder comparable -> D.Decoder a -> D.Decoder (Adjacency comparable a)
-decode decodeKey decodeItem =
+decode : D.Decoder (Adjacency Int Int)
+decode =
+    decodeWith D.int D.int
+
+
+decodeWith : D.Decoder comparable -> D.Decoder a -> D.Decoder (Adjacency comparable a)
+decodeWith decodeKey decodeItem =
     D.list (decodeItems decodeKey decodeItem)
         |> D.map Dict.fromList
 

--- a/src/Kvant/Json/Options.elm
+++ b/src/Kvant/Json/Options.elm
@@ -8,8 +8,8 @@ import Json.Decode as D
 import Json.Encode as E
 
 
-decodePatternSearchOptions : D.Decoder Options.PatternSearch
-decodePatternSearchOptions =
+decodePatternSearch : D.Decoder Options.PatternSearch
+decodePatternSearch =
     D.map3
         (\psize iboundary symmetry ->
             { patternSize = psize
@@ -40,8 +40,8 @@ decodePatternSearchOptions =
         )
 
 
-decodeOutputOptions : D.Decoder Options.Output
-decodeOutputOptions =
+decodeOutput : D.Decoder Options.Output
+decodeOutput =
     D.map3
         (\oboundary width height ->
             ( oboundary, ( width, height ) )
@@ -58,8 +58,8 @@ decodeOutputOptions =
         (D.field "outputHeight" D.int)
 
 
-encodePatternSearchOptions : Options.PatternSearch -> E.Value
-encodePatternSearchOptions opts =
+encodePatternSearch : Options.PatternSearch -> E.Value
+encodePatternSearch opts =
     E.object
         [
 
@@ -89,8 +89,8 @@ encodePatternSearchOptions opts =
         ]
 
 
-encodeOutputOptions : Options.Output -> E.Value
-encodeOutputOptions ( boundary, size ) =
+encodeOutput : Options.Output -> E.Value
+encodeOutput ( boundary, size ) =
     E.object
         [
             ( "outputBoundary"

--- a/src/Kvant/Json/Options.elm
+++ b/src/Kvant/Json/Options.elm
@@ -1,6 +1,6 @@
 module Kvant.Json.Options exposing (..)
 
-import Kvant.Solver.Options exposing (..)
+import Kvant.Solver.Options as Options
 import Kvant.Plane exposing (Plane(..), Boundary(..), Symmetry(..))
 
 
@@ -8,55 +8,44 @@ import Json.Decode as D
 import Json.Encode as E
 
 
-decode : D.Decoder Options
-decode =
-    D.map4
-
-        (\approach outputBoundary otputWidth outputHeight ->
-            Options approach outputBoundary ( otputWidth, outputHeight )
+decodeOverlappingOptions : D.Decoder Options.Overlapping
+decodeOverlappingOptions =
+    D.map3
+        (\psize iboundary symmetry ->
+            { patternSize = psize
+            , boundary = iboundary
+            , symmetry = symmetry
+            }
         )
-
-        (D.field "approach" D.string
+        (D.field "patternSize" <| D.map (\n -> (n, n)) <| D.int)
+        (D.field "inputBoundary" D.string
             |> D.andThen
-                (\approach ->
-                    case approach of
-
-                        "overlapping" ->
-                            D.map3
-                                (\psize iboundary symmetry ->
-                                    Overlapping
-                                        { patternSize = psize
-                                        , inputBoundary = iboundary
-                                        , symmetry = symmetry
-                                        }
-                                )
-                                (D.field "patternSize" <| D.map (\n -> (n, n)) <| D.int)
-                                (D.field "inputBoundary" D.string
-                                    |> D.andThen
-                                        (\boundary ->
-                                            case boundary of
-                                                "bounded" -> D.succeed Bounded
-                                                "periodic" -> D.succeed Periodic
-                                                _ -> D.fail <| "Invalid boundary: " ++ boundary
-                                        )
-                                )
-                                (D.field "symmetry" D.string
-                                    |> D.andThen
-                                        (\symmetry ->
-                                            case symmetry of
-                                                "none" -> D.succeed NoSymmetry
-                                                "flip-only" -> D.succeed FlipOnly
-                                                "rotate-only" -> D.succeed RotateOnly
-                                                "flip-and-rotate" -> D.succeed FlipAndRotate
-                                                _ -> D.fail <| "Invalid symmetry: " ++ symmetry
-                                        )
-                                )
-
-                        "tiled" -> D.succeed Tiled
-                        _ -> D.fail <| "Invalid approach: " ++ approach
+                (\boundary ->
+                    case boundary of
+                        "bounded" -> D.succeed Bounded
+                        "periodic" -> D.succeed Periodic
+                        _ -> D.fail <| "Invalid boundary: " ++ boundary
+                )
+        )
+        (D.field "symmetry" D.string
+            |> D.andThen
+                (\symmetry ->
+                    case symmetry of
+                        "none" -> D.succeed NoSymmetry
+                        "flip-only" -> D.succeed FlipOnly
+                        "rotate-only" -> D.succeed RotateOnly
+                        "flip-and-rotate" -> D.succeed FlipAndRotate
+                        _ -> D.fail <| "Invalid symmetry: " ++ symmetry
                 )
         )
 
+
+decodeOutputOptions : D.Decoder Options.Output
+decodeOutputOptions =
+    D.map3
+        (\oboundary width height ->
+            ( oboundary, ( width, height ) )
+        )
         (D.field "outputBoundary" D.string
             |> D.andThen (\boundary ->
                 case boundary of
@@ -65,70 +54,64 @@ decode =
                     _ -> D.fail <| "Invalid boundary: " ++ boundary
             )
         )
-
         (D.field "outputWidth" D.int)
-
         (D.field "outputHeight" D.int)
 
 
-encode : Options -> E.Value
-encode opts =
-    E.object <|
+encodeOverlappingOptions : Options.Overlapping -> E.Value
+encodeOverlappingOptions opts =
+    E.object
         [
-            ( "approach"
-            , E.string <|
-                case opts.approach of
-                    Overlapping _ -> "overlapping"
-                    Tiled -> "tiled"
+
+            ( "patternSize"
+            , E.int <|
+                case opts.patternSize of
+                    ( n, _ ) -> n
             )
         ,
+
+            ( "inputBoundary"
+            , E.string <|
+                case opts.boundary of
+                    Bounded -> "bounded"
+                    Periodic -> "periodic"
+            )
+        ,
+            ( "symmetry"
+            , E.string <|
+                case opts.symmetry of
+                    NoSymmetry -> "none"
+                    FlipOnly -> "flip-only"
+                    RotateOnly -> "rotate-only"
+                    FlipAndRotate -> "flip-and-rotate"
+            )
+
+        ]
+
+
+encodeOutputOptions : Options.Output -> E.Value
+encodeOutputOptions ( boundary, size ) =
+    E.object
+        [
             ( "outputBoundary"
             , E.string <|
-                case opts.outputBoundary of
+                case boundary of
                     Bounded -> "bounded"
                     Periodic -> "periodic"
             )
         ,
             ( "outputWidth"
             , E.int <|
-                case opts.outputSize of
+                case size of
                     ( width, _ ) -> width
             )
         ,
             ( "outputHeight"
             , E.int <|
-                case opts.outputSize of
+                case size of
                     ( _, height ) -> height
             )
-        ] ++
+        ]
 
-        case opts.approach of
-            Overlapping oopts ->
-                [
 
-                    ( "patternSize"
-                    , E.int <|
-                        case oopts.patternSize of
-                            ( n, _ ) -> n
-                    )
-                ,
 
-                    ( "inputBoundary"
-                    , E.string <|
-                        case oopts.inputBoundary of
-                            Bounded -> "bounded"
-                            Periodic -> "periodic"
-                    )
-                ,
-                    ( "symmetry"
-                    , E.string <|
-                        case oopts.symmetry of
-                            NoSymmetry -> "none"
-                            FlipOnly -> "flip-only"
-                            RotateOnly -> "rotate-only"
-                            FlipAndRotate -> "flip-and-rotate"
-                    )
-
-                ]
-            Tiled ->
-                []

--- a/src/Kvant/Json/Options.elm
+++ b/src/Kvant/Json/Options.elm
@@ -8,8 +8,8 @@ import Json.Decode as D
 import Json.Encode as E
 
 
-decodeOverlappingOptions : D.Decoder Options.Overlapping
-decodeOverlappingOptions =
+decodePatternSearchOptions : D.Decoder Options.PatternSearch
+decodePatternSearchOptions =
     D.map3
         (\psize iboundary symmetry ->
             { patternSize = psize
@@ -58,8 +58,8 @@ decodeOutputOptions =
         (D.field "outputHeight" D.int)
 
 
-encodeOverlappingOptions : Options.Overlapping -> E.Value
-encodeOverlappingOptions opts =
+encodePatternSearchOptions : Options.PatternSearch -> E.Value
+encodePatternSearchOptions opts =
     E.object
         [
 

--- a/src/Kvant/Json/Patterns.elm
+++ b/src/Kvant/Json/Patterns.elm
@@ -13,7 +13,7 @@ import Kvant.Json.Adjacency as Adjacency
 
 decode : D.Decoder P.UniquePatterns
 decode =
-    Adjacency.decode decodePattern
+    Adjacency.decode D.int decodePattern
 
 
 decodePattern : D.Decoder P.Pattern
@@ -29,7 +29,7 @@ decodePattern =
 
 encode : P.UniquePatterns -> E.Value
 encode =
-    Adjacency.encode encodePattern
+    Adjacency.encode E.int encodePattern
 
 
 encodePattern : P.Pattern -> E.Value

--- a/src/Kvant/Json/Patterns.elm
+++ b/src/Kvant/Json/Patterns.elm
@@ -13,7 +13,7 @@ import Kvant.Json.Adjacency as Adjacency
 
 decode : D.Decoder P.UniquePatterns
 decode =
-    Adjacency.decode D.int decodePattern
+    Adjacency.decodeWith D.int decodePattern
 
 
 decodePattern : D.Decoder P.Pattern
@@ -29,7 +29,7 @@ decodePattern =
 
 encode : P.UniquePatterns -> E.Value
 encode =
-    Adjacency.encode E.int encodePattern
+    Adjacency.encodeWith E.int encodePattern
 
 
 encodePattern : P.Pattern -> E.Value

--- a/src/Kvant/Json/Tiles.elm
+++ b/src/Kvant/Json/Tiles.elm
@@ -14,7 +14,7 @@ import Kvant.Json.Adjacency as Adjacency
 
 decode : D.Decoder T.TileAdjacency
 decode =
-    Adjacency.encodeWith decodeTileKey decodeTileKey
+    Adjacency.decodeWith decodeTileKey decodeTileKey
 
 
 decodeTileKey : D.Decoder ( T.TileKey, T.Rotation )

--- a/src/Kvant/Json/Tiles.elm
+++ b/src/Kvant/Json/Tiles.elm
@@ -1,0 +1,39 @@
+module Kvant.Json.Tiles exposing (..)
+
+
+import Dict exposing (Dict)
+import Json.Encode as E
+import Json.Decode as D
+
+
+import Kvant.Vec2 as Vec2
+import Kvant.Tiles as T
+import Kvant.Plane as Plane
+import Kvant.Json.Adjacency as Adjacency
+
+
+decode : D.Decoder T.TileAdjacency
+decode =
+    Adjacency.decode decodeTileKey decodeTileKey
+
+
+decodeTileKey : D.Decoder ( T.TileKey, T.Rotation )
+decodeTileKey =
+    D.map2
+        Tuple.pair
+        (D.field "key" D.string)
+        (D.field "rotation" D.int)
+
+
+encode : T.TileAdjacency -> E.Value
+encode =
+    Adjacency.encode encodeTileKey encodeTileKey
+
+
+encodeTileKey : ( T.TileKey, T.Rotation ) -> E.Value
+encodeTileKey ( key, rotation ) =
+    E.object
+        [ ( "key", E.string key )
+        , ( "rotation", E.int rotation )
+        ]
+

--- a/src/Kvant/Json/Tiles.elm
+++ b/src/Kvant/Json/Tiles.elm
@@ -14,7 +14,7 @@ import Kvant.Json.Adjacency as Adjacency
 
 decode : D.Decoder T.TileAdjacency
 decode =
-    Adjacency.decode decodeTileKey decodeTileKey
+    Adjacency.encodeWith decodeTileKey decodeTileKey
 
 
 decodeTileKey : D.Decoder ( T.TileKey, T.Rotation )
@@ -27,7 +27,7 @@ decodeTileKey =
 
 encode : T.TileAdjacency -> E.Value
 encode =
-    Adjacency.encode encodeTileKey encodeTileKey
+    Adjacency.encodeWith encodeTileKey encodeTileKey
 
 
 encodeTileKey : ( T.TileKey, T.Rotation ) -> E.Value

--- a/src/Kvant/Solver.elm
+++ b/src/Kvant/Solver.elm
@@ -207,15 +207,20 @@ produce
     :  UniquePatterns
     -> Step
     -> Solution
-produce patterns (Step _ _ outputSize status) =
+{-  TODO :  Set a
+    -> (a -> b)
+    -> Step
+    -> Plane (List b)
+-}
+produce adjacencyRules (Step _ _ outputSize status) =
     let
         loadValues : Matches AtomId -> List AtomId
         loadValues matches =
             matches
                 |> Matches.toList
-                |> List.map (\patternId ->
-                    patterns
-                        |> Dict.get patternId
+                |> List.map (\atomId ->
+                    adjacencyRules
+                        |> Dict.get atomId
                         |> Maybe.andThen (.subject >> Plane.get (0, 0))
                     )
                 |> List.filterMap identity
@@ -224,7 +229,7 @@ produce patterns (Step _ _ outputSize status) =
         fromWave wave = wave |> Plane.map loadValues
     in
         fromWave <| case status of
-            Initial -> initWave (Dict.keys patterns) outputSize
+            Initial -> initWave (Dict.keys adjacencyRules) outputSize
             InProgress _ wave -> wave
             Solved wave -> wave
             Terminated -> Plane.empty outputSize

--- a/src/Kvant/Solver/Options.elm
+++ b/src/Kvant/Solver/Options.elm
@@ -17,3 +17,14 @@ type alias PatternSearch =
 type alias Output = ( Boundary, Size )
 
 
+
+defaultPatternSearch : PatternSearch
+defaultPatternSearch =
+    { patternSize = (2, 2)
+    , boundary = Bounded
+    , symmetry = NoSymmetry
+    }
+
+
+defaultOutput : Output
+defaultOutput = ( Bounded, (10, 10) )

--- a/src/Kvant/Solver/Options.elm
+++ b/src/Kvant/Solver/Options.elm
@@ -6,7 +6,7 @@ import Kvant.Plane exposing (Plane(..), Size, Boundary(..), Symmetry(..))
 -- import Xml.Decode as Xml
 
 
-type alias Overlapping =
+type alias PatternSearch =
     { patternSize : Size -- FIXME: use just square patterns
     , boundary : Boundary
     , symmetry : Symmetry -- FIXME: use in search

--- a/src/Kvant/Solver/Options.elm
+++ b/src/Kvant/Solver/Options.elm
@@ -6,18 +6,14 @@ import Kvant.Plane exposing (Plane(..), Size, Boundary(..), Symmetry(..))
 -- import Xml.Decode as Xml
 
 
-type alias Options =
-    { approach : Approach
-    , outputBoundary : Boundary
-    , outputSize : Size
+type alias Overlapping =
+    { patternSize : Size -- FIXME: use just square patterns
+    , boundary : Boundary
+    , symmetry : Symmetry -- FIXME: use in search
+    -- TODO: ground : Int
     }
 
 
-type Approach
-    = Overlapping
-        { patternSize : Size -- FIXME: use just square patterns
-        , inputBoundary : Boundary
-        , symmetry : Symmetry -- FIXME: use in search
-        -- TODO: ground : Int
-        }
-    | Tiled
+type alias Output = ( Boundary, Size )
+
+

--- a/src/Kvant/Tiles.elm
+++ b/src/Kvant/Tiles.elm
@@ -6,10 +6,9 @@ import Dict exposing (Dict)
 import Set exposing (Set)
 
 
-
 import Kvant.Plane exposing (Plane, Offset)
-import Kvant.Adjacency as A
-import Kvant.Neighbours exposing (Neighbours, Cardinal(..), Direction)
+import Kvant.Adjacency exposing (Adjacency)
+import Kvant.Neighbours exposing (Cardinal(..), Direction)
 import Kvant.Neighbours as Neighbours
 import Kvant.Neighbours as D exposing (Direction(..))
 import Kvant.Matches as Matches exposing (Matches)
@@ -46,7 +45,7 @@ type alias TileSet = ( Format, List TileInfo )
 type alias TilesPlane = Plane (TileKey, Rotation)
 
 
-type alias Adjacency = A.Adjacency (TileKey, Rotation) (TileKey, Rotation)
+type alias TileAdjacency = Adjacency (TileKey, Rotation) (TileKey, Rotation)
 
 
 type alias TileGrid = Array (Array (TileKey, Rotation))
@@ -253,7 +252,7 @@ findMatches tiles rules ( currentTile, currentRotation ) =
         |> Neighbours.toDict
 
 
-buildAdjacencyRules : List TileInfo -> List Rule -> Adjacency
+buildAdjacencyRules : List TileInfo -> List Rule -> TileAdjacency
 buildAdjacencyRules tiles rules =
     tiles
         |> List.concatMap


### PR DESCRIPTION
Since tiling approach doesn't need patterns, but the solving is the same algorithm both for tiled and overlapping cases, I need to make the solving process generic: to work not only with UniquePatterns, but with any Adjacency, tiles or patterns, no matter.

This will also allow to not request patterns from Worker when there are rules and split Worker requests into two: one for patterns, if needed, one for actual solving.